### PR TITLE
Ban import of com.google.common.base.Optional

### DIFF
--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -98,6 +98,10 @@
         <property name="format" value="^import junit\.framework\..*"/>
         <property name="message" value="Use JUnit v4 instead."/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import com\.google\.common\.base\.Optional"/>
+        <property name="message" value="Use java.util.Optional instead."/>
+    </module>
 
     <!-- Always throw propagate result -->
     <module name="RegexpSingleline">


### PR DESCRIPTION
So in cases where we really need to interop we can always refer to it by full classpath. This just prevents it from entering common circulation in the code (once someone imports it in one place it will spawn more usage).