### PR TITLE
disable AvoidStaticImports check for tests

### DIFF
--- a/src/main/resources/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle-suppressions.xml
@@ -28,6 +28,8 @@
     <suppress checks="." files=".*[\\/]?generated-sources[\\/].*"/>
 
     <!-- Exclude certain checks from test code -->
+    <suppress checks="AvoidStaticImport" files=".*Test\.java"/>
+    <suppress checks="AvoidStaticImport" files=".*TestPerf\.java"/>
     <suppress checks="JavadocVariable" files=".*Test\.java"/>
     <suppress checks="JavadocVariable" files=".*TestPerf\.java"/>
     <suppress checks="JavadocVariable" files=".*IT\.java"/>

--- a/src/main/resources/checkstyle-suppressions.xml
+++ b/src/main/resources/checkstyle-suppressions.xml
@@ -30,6 +30,8 @@
     <!-- Exclude certain checks from test code -->
     <suppress checks="AvoidStaticImport" files=".*Test\.java"/>
     <suppress checks="AvoidStaticImport" files=".*TestPerf\.java"/>
+    <suppress checks="AvoidStaticImport" files=".*IT\.java"/>
+    <suppress checks="AvoidStaticImport" files=".*ITPerf\.java"/>
     <suppress checks="JavadocVariable" files=".*Test\.java"/>
     <suppress checks="JavadocVariable" files=".*TestPerf\.java"/>
     <suppress checks="JavadocVariable" files=".*IT\.java"/>


### PR DESCRIPTION
For ease of use when importing assertions and matchers.