### PR TITLE
disallow static imports for any non-testing library

### DIFF
--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -131,6 +131,12 @@
         <property name="message" value="Place the @Nullable annotation before the java modifiers (e.g. final, static, private, etc.)."/>
     </module>
 
+    <!-- Check that static imports are not used for anything other than testing libraries -->
+    <module name="RegexpSingleline">
+        <property name="format" value='^import static (?!org\.junit|org\.hamcrest|org\.mockito|com\.github\.tomakehurst\.wiremock)'/>
+        <property name="message" value="Only use static member imports for testing libraries."/>
+    </module>
+
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>


### PR DESCRIPTION
Allows the usual suspects: junit, mockito, hamcrest, wiremock