### PR TITLE
Switch import order so that static import follow non-static imports.

### DIFF
--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -174,7 +174,8 @@
             <property name="groups" value="*,/^javax?\./"/>
             <!-- This ensures that static imports go first. -->
             <property name="separated" value="true"/>
-            <property name="option" value="top"/>
+            <property name="option" value="bottom"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
             <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
         </module>
 


### PR DESCRIPTION
Changes static imports to be at the bottom and enforces that static imports be sorted.