### PR TITLE
Update Comment About Import Order

### DIFF
--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -178,7 +178,7 @@
         <module name="ImportOrder">
             <property name="severity" value="error"/>
             <property name="groups" value="*,/^javax?\./"/>
-            <!-- This ensures that static imports go first. -->
+            <!-- This ensures that static imports go last. -->
             <property name="separated" value="true"/>
             <property name="option" value="bottom"/>
             <property name="sortStaticImportsAlphabetically" value="true"/>


### PR DESCRIPTION
Fix checkstyle static import position to be after non-static. Originally introduced in:

https://github.com/ArpNetworking/build-resources/commit/5e2c40d9b2b908dbc5898780a69d3774bfd89661#diff-79031d8531ee481868b31b83b763e2d6