### PR TITLE
Fix quoting of arguments.

### DIFF
--- a/src/main/resources/appAssemblerUnixBinTemplate
+++ b/src/main/resources/appAssemblerUnixBinTemplate
@@ -105,15 +105,23 @@ AFTER_OPTS=""
 SPLIT_FOUND=
 for ARG in "$@"; do
   VALUE=
-  eval VALUE="${ARG}"
+  eval "VALUE=\"${ARG}\""
+  if [ "${ARG}" = "${VALUE}" ]; then
+    case "${VALUE}" in
+      *\'*)
+       VALUE=`printf "%s" "$VALUE" | sed "s/'/'\"'\"'/g"`
+       ;;
+    *) : ;;
+    esac
+  fi
   if [ -z "${SPLIT_FOUND}" ]; then
     if [ "${VALUE}" = "--" ]; then
       SPLIT_FOUND="true"
     else
-      BEFORE_OPTS="${BEFORE_OPTS} '${VALUE}'"
+      BEFORE_OPTS="${BEFORE_OPTS} ${VALUE}"
     fi
   else
-    AFTER_OPTS="${AFTER_OPTS} '${VALUE}'"
+    AFTER_OPTS="${AFTER_OPTS} ${VALUE}"
   fi
 done
 if [ -z "${SPLIT_FOUND}" ]; then


### PR DESCRIPTION
1) Quoted arguments are not honored.

Before:
```
$ s.sh "foo bar"
s.sh: line 9: bar: command not found
JAVA_OPTS=
APP_OPTS=
```

After:
```
$ s.sh "foo bar"
JAVA_OPTS=
APP_OPTS= foo bar
```

2) Single quotes are mangled.

Before:
```
$ s.sh "foo'bar"
s.sh: eval: line 9: unexpected EOF while looking for matching `''
s.sh: eval: line 10: syntax error: unexpected end of file
JAVA_OPTS=
APP_OPTS=
```

After:
```
$ s.sh "foo'bar"
JAVA_OPTS=
APP_OPTS= foo'"'"'bar
```

3) Environment variables can specify one or more arguments (no quoting):

Before:
```
$ export ADDITIONAL_JAVA_OPTS="'-Dj2=123 456'"
$ s.sh '${ADDITIONAL_JAVA_OPTS}'
JAVA_OPTS=
APP_OPTS= ''-Dj2=123 456''
```

After:
```
$ export ADDITIONAL_JAVA_OPTS="'-Dj2=123 456'"
$ s.sh '${ADDITIONAL_JAVA_OPTS}'
JAVA_OPTS=
APP_OPTS= '-Dj2=123 456'
```

The only downside of this is that if you combine a value with quotes and environment variables we won't escape it for you since we don't know whether it should be a single argument or a collection of arguments. I will add a note about this to the calling blocks in MAD and MP.