### PR TITLE
Make the chown into best-effort

### DIFF
--- a/src/main/resources/docker-entrypoint.sh
+++ b/src/main/resources/docker-entrypoint.sh
@@ -188,10 +188,14 @@ ${os}_create_user_group "${cfg_user}" "${cfg_uid}" "${cfg_gid}"
 
 # Modify the ownership of the specified directories
 eval "set -- ${cfg_directories}"
+# Disable fail on error so that this becomes a best effort step
+set +e
 for cfg_directory in "$@"; do
   log_out "Setting ownership of: ${cfg_directory}"
   find "${cfg_directory}" \! -user "${cfg_user}" -exec chown "${cfg_user}:${cfg_user}" '{}' +
 done
+# Re-enable fail on error
+set -e
 
 # Execute the provided command as the specified user
 eval "set -- ${command_args}"


### PR DESCRIPTION
There may be things you can't chown in the config directories. While we still try to chown everything, we shouldn't fail if we can't.

Ex: kubernetes config objects are read-only at the filesystem level